### PR TITLE
priority queue api and implementation

### DIFF
--- a/src/main/java/net/greghaines/jesque/client/Client.java
+++ b/src/main/java/net/greghaines/jesque/client/Client.java
@@ -38,6 +38,20 @@ public interface Client {
     void enqueue(String queue, Job job);
 
     /**
+     * Queues a job in a given queue to be run.
+     *
+     * @param queue
+     *            the queue to add the Job to
+     * @param job
+     *            the job to be enqueued
+     * @param priority
+     *            the job's priority in the queue
+     * @throws IllegalArgumentException
+     *             if the queue is null or empty or if the job is null
+     */
+    void enqueue(String queue, Job job, double priority);
+
+    /**
      * Queues a job with high priority in a given queue to be run.
      * 
      * @param queue

--- a/src/main/java/net/greghaines/jesque/client/ClientImpl.java
+++ b/src/main/java/net/greghaines/jesque/client/ClientImpl.java
@@ -113,6 +113,15 @@ public class ClientImpl extends AbstractClient {
      * {@inheritDoc}
      */
     @Override
+    protected void doEnqueue(final String queue, final String jobJson, final double priority) throws Exception {
+        ensureJedisConnection();
+        doEnqueue(this.jedis, getNamespace(), queue, jobJson, priority);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     protected void doPriorityEnqueue(final String queue, final String jobJson) {
         ensureJedisConnection();
         doPriorityEnqueue(this.jedis, getNamespace(), queue, jobJson);

--- a/src/main/java/net/greghaines/jesque/client/ClientPoolImpl.java
+++ b/src/main/java/net/greghaines/jesque/client/ClientPoolImpl.java
@@ -69,6 +69,23 @@ public class ClientPoolImpl extends AbstractClient {
      * {@inheritDoc}
      */
     @Override
+    protected void doEnqueue(final String queue, final String jobJson, final double priority) throws Exception {
+        PoolUtils.doWorkInPool(this.jedisPool, new PoolWork<Jedis, Void>() {
+            /**
+             * {@inheritDoc}
+             */
+            @Override
+            public Void doWork(final Jedis jedis) {
+                doEnqueue(jedis, getNamespace(), queue, jobJson, priority);
+                return null;
+            }
+        });
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     protected void doPriorityEnqueue(final String queue, final String jobJson) throws Exception {
         PoolUtils.doWorkInPool(this.jedisPool, new PoolWork<Jedis, Void>() {
             /**

--- a/src/main/java/net/greghaines/jesque/utils/ResqueConstants.java
+++ b/src/main/java/net/greghaines/jesque/utils/ResqueConstants.java
@@ -61,7 +61,10 @@ public interface ResqueConstants {
     String CHANNEL = "channel";
     String INFLIGHT = "inflight";
     String FREQUENCY = "frequency";
-
+    String QUEUE_TYPES = "queueTypes";
+    String PRIORITY_QUEUE = "priority";
+    String REGULAR_QUEUE = "regular";
+    String DELAYED_QUEUE = "delayed";
     /**
      * Default channel for admin jobs
      */

--- a/src/main/java/net/greghaines/jesque/worker/WorkerImpl.java
+++ b/src/main/java/net/greghaines/jesque/worker/WorkerImpl.java
@@ -447,7 +447,7 @@ public class WorkerImpl implements Worker {
      */
     protected String pop(final String curQueue) {
         final String key = key(QUEUE, curQueue);
-        return (String) this.jedis.evalsha(this.popScriptHash.get(), 3, key, key(INFLIGHT, this.name, curQueue), 
+        return (String) this.jedis.evalsha(this.popScriptHash.get(), 3, key, key(INFLIGHT, this.name, curQueue),
                 JesqueUtils.createRecurringHashKey(key), Long.toString(System.currentTimeMillis()));
     }
 

--- a/src/test/java/net/greghaines/jesque/PriorityQueueTest.java
+++ b/src/test/java/net/greghaines/jesque/PriorityQueueTest.java
@@ -1,0 +1,134 @@
+package net.greghaines.jesque;
+
+import net.greghaines.jesque.client.Client;
+import net.greghaines.jesque.client.ClientImpl;
+import net.greghaines.jesque.utils.JedisUtils;
+import net.greghaines.jesque.utils.JesqueUtils;
+import net.greghaines.jesque.worker.*;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import redis.clients.jedis.Jedis;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static net.greghaines.jesque.TestUtils.createJedis;
+import static net.greghaines.jesque.utils.JesqueUtils.*;
+import static net.greghaines.jesque.utils.ResqueConstants.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+/**
+ * @author itaim
+ */
+public class PriorityQueueTest {
+
+    private static final Config config = new ConfigBuilder().build();
+    private static final String testQueue = "foo";
+    private static final String priorityTestQueue = "fooPriority";
+
+    @Before
+    public void resetRedis() {
+        TestUtils.resetRedis(config);
+    }
+
+    @Test
+    public void testCode() throws Exception {
+
+        // Enqueue the job before worker is created and started
+        final List<Job> jobs = new ArrayList<Job>(10);
+        for (int i = 0; i < 10; i++) {
+            jobs.add(new Job("TestAction", new Object[]{i, Double.valueOf(i), true, "test", Arrays.asList("inner", 4.5)}));
+        }
+        TestUtils.enqueueJobsWithPriority(priorityTestQueue, jobs, config);
+        jobs.clear();
+        for (int i = 10; i < 20; i++) {
+            jobs.add(new Job("TestAction", new Object[]{i, 2.3, true, "test", Arrays.asList("inner", 4.5)}));
+        }
+        TestUtils.enqueueJobs(testQueue, jobs, config);
+
+        Jedis jedis = createJedis(config);
+        try { // Assert that we enqueued the job
+            Assert.assertEquals(Long.valueOf(10),
+                    jedis.zcount(createKey(config.getNamespace(), QUEUE, priorityTestQueue), "-inf", "+inf"));
+        } finally {
+            jedis.quit();
+        }
+
+        // Create and start worker
+        final Worker worker = new WorkerImpl(config, Arrays.asList(priorityTestQueue),
+                new MapBasedJobFactory(map(entry("TestAction", TestAction.class))));
+        final StringBuilder processOrder = new StringBuilder();
+        worker.getWorkerEventEmitter().addListener(new WorkerListener() {
+            @Override
+            public void onEvent(WorkerEvent event, Worker worker, String queue, Job job, Object runner, Object result, Throwable t) {
+                processOrder.append(job.getArgs()[1]).append(",");
+            }
+        }, WorkerEvent.JOB_PROCESS);
+        final Thread workerThread = new Thread(worker);
+        workerThread.start();
+
+        // start second thread
+        final Worker worker2 = new WorkerImpl(config, Arrays.asList(testQueue),
+                new MapBasedJobFactory(map(entry("TestAction", TestAction.class))));
+        final Thread workerThread2 = new Thread(worker2);
+        workerThread2.start();
+
+        try { // Wait a bit to ensure the worker had time to process the job
+            Thread.sleep(3000);
+        } finally { // Stop the worker
+            TestUtils.stopWorker(worker, workerThread);
+        }
+
+        // Assert that the job was run by the worker
+        jedis = createJedis(config);
+        try {
+            Assert.assertEquals(String.valueOf(20), jedis.get(createKey(config.getNamespace(), STAT, PROCESSED)));
+            Assert.assertNull(jedis.get(createKey(config.getNamespace(), STAT, FAILED)));
+            Assert.assertEquals(Long.valueOf(0),
+                    jedis.zcount(createKey(config.getNamespace(), QUEUE, priorityTestQueue), "-inf", "+inf"));
+            Assert.assertEquals("9.0,8.0,7.0,6.0,5.0,4.0,3.0,2.0,1.0,0.0,", processOrder.toString());
+        } finally {
+            jedis.quit();
+        }
+    }
+
+    @Test
+    public void testReassignQueueTypeWhenEmpty() throws Exception {
+        final Client client = new ClientImpl(config);
+        Job job = new Job("TestAction", new Object[]{1, 2.3, true, "test", Arrays.asList("inner", 4.5)});
+        client.enqueue(priorityTestQueue, job, 7.0);
+
+        final String key = JesqueUtils.createKey(config.getNamespace(), QUEUE, priorityTestQueue);
+        Jedis jedis = new Jedis(config.getHost(), config.getPort(), config.getTimeout());
+        assertThat(JedisUtils.isPriorityQueue(jedis, key), is(true));
+
+        executeWorker(priorityTestQueue, 300);
+
+        client.enqueue(priorityTestQueue, job);
+        assertThat(JedisUtils.isRegularQueue(jedis, key), is(true));
+
+        executeWorker(priorityTestQueue, 300);
+
+        client.delayedEnqueue(priorityTestQueue, job, System.currentTimeMillis() + 100);
+
+        assertThat(JedisUtils.isDelayedQueue(jedis, key), is(true));
+
+        executeWorker(priorityTestQueue, 400);
+
+        jedis.close();
+
+    }
+
+    private void executeWorker(String queue, int sleep) throws InterruptedException {
+        final Worker worker = new WorkerImpl(config, Arrays.asList(queue),
+                new MapBasedJobFactory(map(entry("TestAction", TestAction.class))));
+        final Thread workerThread = new Thread(worker);
+        workerThread.start();
+
+        Thread.sleep(sleep);
+        TestUtils.stopWorker(worker, workerThread);
+    }
+}

--- a/src/test/java/net/greghaines/jesque/TestUtils.java
+++ b/src/test/java/net/greghaines/jesque/TestUtils.java
@@ -83,6 +83,17 @@ public final class TestUtils {
         }
     }
 
+    public static void enqueueJobsWithPriority(final String queue, final List<Job> jobs, final Config config) {
+        final Client client = new ClientImpl(config);
+        try {
+            for (final Job job : jobs) {
+                client.enqueue(queue, job, (Double) job.getArgs()[1]);
+            }
+        } finally {
+            client.end();
+        }
+    }
+
     public static void stopWorker(final JobExecutor worker, final Thread workerThread) {
         stopWorker(worker, workerThread, false);
     }

--- a/src/test/java/net/greghaines/jesque/utils/TestJedisUtils.java
+++ b/src/test/java/net/greghaines/jesque/utils/TestJedisUtils.java
@@ -1,22 +1,23 @@
 package net.greghaines.jesque.utils;
 
-import static net.greghaines.jesque.TestUtils.createJedis;
-
 import net.greghaines.jesque.Config;
 import net.greghaines.jesque.ConfigBuilder;
 import net.greghaines.jesque.TestUtils;
-
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-
 import redis.clients.jedis.Jedis;
 
+import static net.greghaines.jesque.TestUtils.createJedis;
+import static net.greghaines.jesque.utils.ResqueConstants.DELAYED_QUEUE;
+import static net.greghaines.jesque.utils.ResqueConstants.QUEUE_TYPES;
+import static net.greghaines.jesque.utils.ResqueConstants.REGULAR_QUEUE;
+
 public class TestJedisUtils {
-    
+
     private static final Config CONFIG = new ConfigBuilder().build();
     private static final String TEST_KEY = "foo";
-    
+
     @Before
     public void resetRedis() {
         TestUtils.resetRedis(CONFIG);
@@ -28,7 +29,7 @@ public class TestJedisUtils {
         Assert.assertTrue(JedisUtils.ensureJedisConnection(jedis));
         Assert.assertTrue(JedisUtils.testJedisConnection(jedis));
     }
-    
+
     @Test
     public void testEnsureJedisConnection_Fail() {
         final Jedis jedis = createJedis(CONFIG);
@@ -41,23 +42,23 @@ public class TestJedisUtils {
     public void testTestJedisConnection_Success() {
         Assert.assertTrue(JedisUtils.testJedisConnection(createJedis(CONFIG)));
     }
-    
+
     @Test
     public void testTestJedisConnection_Fail() {
         final Jedis jedis = createJedis(CONFIG);
         jedis.disconnect();
         Assert.assertFalse(JedisUtils.testJedisConnection(jedis));
     }
-    
+
     @Test
     public void testReconnect_Success() {
         Assert.assertTrue(JedisUtils.reconnect(createJedis(CONFIG), 1, 1));
     }
-    
+
     @Test
     public void testIsRegularQueue_Success() {
         final Jedis jedis = createJedis(CONFIG);
-        jedis.lpush(TEST_KEY, "bar");
+        jedis.hset(QUEUE_TYPES, TEST_KEY, REGULAR_QUEUE);
         Assert.assertTrue(JedisUtils.isRegularQueue(jedis, TEST_KEY));
     }
 
@@ -69,7 +70,7 @@ public class TestJedisUtils {
     @Test
     public void testIsDelayedQueue_Success() {
         final Jedis jedis = createJedis(CONFIG);
-        jedis.zadd(TEST_KEY, 1.0, "bar");
+        jedis.hset(QUEUE_TYPES, TEST_KEY, DELAYED_QUEUE);
         Assert.assertTrue(JedisUtils.isDelayedQueue(jedis, TEST_KEY));
     }
 
@@ -77,14 +78,14 @@ public class TestJedisUtils {
     public void testIsDelayedQueue_Failure() {
         Assert.assertFalse(JedisUtils.isDelayedQueue(createJedis(CONFIG), TEST_KEY));
     }
-    
+
     @Test
     public void testIsKeyUsed_Success() {
         final Jedis jedis = createJedis(CONFIG);
         jedis.set(TEST_KEY, "bar");
         Assert.assertTrue(JedisUtils.isKeyUsed(jedis, TEST_KEY));
     }
-    
+
     @Test
     public void testIsKeyUsed_Failure() {
         Assert.assertFalse(JedisUtils.isKeyUsed(createJedis(CONFIG), "foo"));
@@ -99,13 +100,31 @@ public class TestJedisUtils {
 
     @Test
     public void testCanUseAsDelayedQueue_Success_None() {
-        Assert.assertTrue(JedisUtils.canUseAsDelayedQueue(createJedis(CONFIG), TEST_KEY));
+        Jedis jedis = createJedis(CONFIG);
+        jedis.hset(QUEUE_TYPES, TEST_KEY, REGULAR_QUEUE);
+        Assert.assertTrue(JedisUtils.canUseAsDelayedQueue(jedis, TEST_KEY));
     }
 
     @Test
     public void testCanUseAsDelayedQueue_Failure() {
         final Jedis jedis = createJedis(CONFIG);
-        jedis.set(TEST_KEY, "bar");
+        jedis.lpush(TEST_KEY, "bar");
+        jedis.hset(QUEUE_TYPES, TEST_KEY, REGULAR_QUEUE);
         Assert.assertFalse(JedisUtils.canUseAsDelayedQueue(jedis, TEST_KEY));
+    }
+
+    @Test
+    public void testCanUseAsRegularQueue_Failure() {
+        final Jedis jedis = createJedis(CONFIG);
+        jedis.zadd(TEST_KEY, 2.0, "bar");
+        jedis.hset(QUEUE_TYPES, TEST_KEY, DELAYED_QUEUE);
+        Assert.assertFalse(JedisUtils.canUseAsRegularQueue(jedis, TEST_KEY));
+    }
+
+    @Test
+    public void testCanUseAsRegularQueue_Success_None() {
+        final Jedis jedis = createJedis(CONFIG);
+        jedis.hset(QUEUE_TYPES, TEST_KEY, DELAYED_QUEUE);
+        Assert.assertTrue(JedisUtils.canUseAsRegularQueue(jedis, TEST_KEY));
     }
 }


### PR DESCRIPTION
So basically priority queue is implemented based on redis sorted set.

jesque currently deals with two types of queues: regular and delayed/recurring
regular is a redis list and delayed is using  sorted set where the score is the job's next execution timestamp.

these queues are distinct once you added a regular job to a queue you cannot add a delayed/recurring job to it and vice versa. 

it is assumed that if the data structure type is sorted set then it is a delayed/recurring queue

This had to be changed so I added a hash structure that stores for each queue name its type regular/delayed/priority

The actual queue polling action is done in a pre-loaded lua script

Other than that testing in this project is sporadic so I remained loyal to its style.

@shlomisut @nirfeldman @royudassin

Are we going to add a jenkins job for this? because if we do it needs a redis installation.
or I can just do it insurgent style, build and upload to artifactory from my machine.  