### PR TITLE
pom.xml: Allow overriding artifact `version` in commandline

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>net.greghaines</groupId>
     <artifactId>jesque</artifactId>
-    <version>2.1.2-SNAPSHOT</version>
+    <version>${ciVersion}</version>
     <packaging>jar</packaging>
     <name>Jesque</name>
     <description>An implementation of Resque in Java</description>
@@ -18,6 +18,7 @@
         <maven>3.0.0</maven>
     </prerequisites>
     <properties>
+        <ciVersion>2.1.2-SNAPSHOT</ciVersion>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jedis.version>2.8.1</jedis.version>
         <jackson.version>2.7.3</jackson.version>


### PR DESCRIPTION
Overriding is done by adding `-DciVersion=1.2.3-VERSION` in commandline

e.g 
> mvn -DciVersion=1.2.3-VERSION install
